### PR TITLE
fix small typo

### DIFF
--- a/chrome/locale/en-US/rules.properties
+++ b/chrome/locale/en-US/rules.properties
@@ -1,5 +1,5 @@
 ruleName=Rule %S
-ruleWarning=Do you realy want to send message from %S?\nMaybe we should use %S instead?
+ruleWarning=Do you really want to send message from %S?\nMaybe we should use %S instead?
 ruleWarnCaption=Identity Inconsistency
 ruleWarnSend=&Send it anyway
 ruleWarnCorrect=&Apply suggestion && Send
@@ -9,6 +9,6 @@ ccWarning=There is no TO recipient, only CC/BCC
 ccWarnCaption=Recipient Inconsistency
 ccWarnSend=Send it anyway
 ccWarnCheck=Disable this warning
-ruleWarningSave=Do you realy want to save message with 'From' is %S?\nMaybe we should use %S instead?
+ruleWarningSave=Do you really want to save message with 'From' is %S?\nMaybe we should use %S instead?
 ruleWarnSave=&Save it anyway
 ruleWarnCorrectSave=&Apply suggestion && Save


### PR DESCRIPTION
Typo in warning messages: realy => realy.